### PR TITLE
Expand date and time generation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Head over to the wiki to find [examples of what each generator outputs when used
   - Random SHA-1 hash
   - Random SHA-265 hash
 - Dates and times
-  - Random date (YYYY-MM-DD)
-  - Random time (HH:MM:SS)
-  - Random date and time
+  - Random date
+  - Random time
+  - Random date and time (ISO-8601)
 - Colors
   - Random hexadecimal color
   - Random RGB color

--- a/RandomizeEverything.novaextension/README.md
+++ b/RandomizeEverything.novaextension/README.md
@@ -6,7 +6,7 @@ Randomize Everything is a Nova extension that adds commands to randomly generate
 
 Once installed and activated, Randomize Everything can be accessed several ways:
 
-- Through the Command Palette, my personal favourite ('View' and 'Command Palette...' in the menu, <kbd>⌘ Command</kbd> + <kbd>⇧ Shift</kbd> + <kbd>P</kbd>).
+- Through the Command Palette, my personal favourite ('View' and 'Command Palette...' in the menu, <kbd>⌘ Command</kbd> + <kbd>⇧ Shift</kbd> + <kbd>P</kbd> by default).
 - As an option in the Editor menu ('Editor' and 'Randomize Everything'), when a compatible document is open.
 - Via the right-click context menu, when a compatible document is open.
 

--- a/RandomizeEverything.novaextension/extension.json
+++ b/RandomizeEverything.novaextension/extension.json
@@ -3,7 +3,7 @@
   "name": "Randomize Everything",
   "organization": "querkmachine",
   "description": "Generate random placeholder content anywhere.",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "repository": "https://github.com/querkmachine/nova-randomize-everything",
   "bugs": "https://github.com/querkmachine/nova-randomize-everything/issues",
   "license": "MIT",
@@ -102,17 +102,17 @@
       },
       { "separator": true },
       {
-        "title": "Random date (YYYY-MM-DD)",
-        "command": "random.dateISO8601",
+        "title": "Random date",
+        "command": "random.date",
         "when": "editorHasFocus"
       },
       {
-        "title": "Random time (HH:MM:SS)",
-        "command": "random.timeISO8601",
+        "title": "Random time",
+        "command": "random.time",
         "when": "editorHasFocus"
       },
       {
-        "title": "Random date and time",
+        "title": "Random date and time (ISO-8601)",
         "command": "random.datetimeISO8601",
         "when": "editorHasFocus"
       },
@@ -240,6 +240,38 @@
       "title": "Dates and times",
       "children": [
         {
+          "key": "random.dateFormat",
+          "title": "Date format",
+          "description": "The format returned by the 'random date' generator.",
+          "type": "enum",
+          "radio": true,
+          "default": "iso",
+          "values": [
+            ["iso", "YYYY-MM-DD"],
+            ["ddmmyyyy", "DD/MM/YYYY"],
+            ["mmddyyyy", "MM/DD/YYYY"]
+          ]
+        },
+        {
+          "key": "random.timeFormat",
+          "title": "Time format",
+          "description": "The format returned by the 'random time' generator.",
+          "type": "enum",
+          "radio": true,
+          "default": "24hour",
+          "values": [
+            ["24hour", "24 hour (00:00 to 23:59)"],
+            ["12hour", "12 hour (12:00 a.m. to 11:59 p.m.)"]
+          ]
+        },
+        {
+          "key": "random.timeIncludeSeconds",
+          "title": "Include seconds",
+          "description": "Include seconds in the output of the 'random time' generator.",
+          "type": "boolean",
+          "default": true
+        },
+        {
           "key": "random.yearMin",
           "title": "Earliest possible year",
           "description": "The earliest year that a generated date can be in.",
@@ -269,7 +301,7 @@
           "values": [
             ["full", "Use a randomized timezone offset (e.g. -05:00)"],
             ["utc", "Always use the UTC timezone (Z)"],
-            ["none", "Do not use a timezone indicator"]
+            ["none", "Don't include a timezone indicator"]
           ]
         }
       ]

--- a/src/generators/datetime.mjs
+++ b/src/generators/datetime.mjs
@@ -57,17 +57,55 @@ function timezone(configOption) {
   }
 }
 
-export function dateISO8601({ minYear, maxYear } = {}) {
-  return randomDateTime({ minYear, maxYear }).slice(0, 10);
+export function time({ minYear, maxYear, format, includeSeconds } = {}) {
+  const randomTime = randomDateTime({ minYear, maxYear }).slice(
+    11,
+    includeSeconds ? 19 : 16,
+  );
+
+  switch (format) {
+    case "12hour":
+      const rawHour = Number(randomTime.slice(0, 2));
+      let formatHour = rawHour;
+
+      if (rawHour === 0) {
+        formatHour = 12;
+      } else if (rawHour > 12) {
+        formatHour = Math.floor(rawHour / 2);
+      }
+
+      return `${formatHour}${randomTime.slice(2)} ${rawHour >= 12 ? "p.m." : "a.m."}`;
+      break;
+    case "24hour":
+    default:
+      return randomTime;
+      break;
+  }
 }
 
-export function timeISO8601({ minYear, maxYear } = {}) {
-  return randomDateTime({ minYear, maxYear }).slice(11, 19);
+export function date({ minYear, maxYear, format } = {}) {
+  const randomDate = randomDateTime({ minYear, maxYear }).slice(0, 10);
+  const dateParts = randomDate.split("-");
+
+  switch (format) {
+    case "ddmmyyyy":
+      return `${dateParts[2]}/${dateParts[1]}/${dateParts[0]}`;
+      break;
+    case "mmddyyyy":
+      return `${dateParts[1]}/${dateParts[2]}/${dateParts[0]}`;
+      break;
+    case "iso":
+    default:
+      return randomDate;
+      break;
+  }
 }
 
 export function datetimeISO8601({ minYear, maxYear, timezoneType } = {}) {
-  return `${dateISO8601({ minYear, maxYear })}T${timeISO8601({
+  return `${date({ minYear, maxYear, format: "iso" })}T${time({
     minYear,
     maxYear,
+    format: "24hour",
+    includeSeconds: true,
   })}${timezone(timezoneType)}`;
 }

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -12,8 +12,8 @@ import {
   countryISO3166numeric,
 } from "./generators/country";
 import {
-  dateISO8601,
-  timeISO8601,
+  date as datestamp,
+  time as timestamp,
   datetimeISO8601,
 } from "./generators/datetime";
 import { hashMD5, hashSHA1, hashSHA256 } from "./generators/hash";
@@ -55,7 +55,7 @@ function promptForInput(settings = {}) {
       } else if (settings.fallbackValue) {
         settings.cb(settings.fallbackValue);
       }
-    }
+    },
   );
 }
 
@@ -64,21 +64,21 @@ export function activate() {
     insertAtPosition(editor, () =>
       colorHex({
         capitalized: nova.config.get("random.hexColorCapitalize", "boolean"),
-      })
+      }),
     );
   });
   nova.commands.register("random.colorRGB", (editor) => {
     insertAtPosition(editor, () =>
       colorRGB({
         cssFormatted: nova.config.get("random.colorsCSSFormatted", "boolean"),
-      })
+      }),
     );
   });
   nova.commands.register("random.colorHSL", (editor) => {
     insertAtPosition(editor, () =>
       colorHSL({
         cssFormatted: nova.config.get("random.colorsCSSFormatted", "boolean"),
-      })
+      }),
     );
   });
   nova.commands.register("random.computerAddressIPV4", (editor) => {
@@ -112,20 +112,23 @@ export function activate() {
   nova.commands.register("random.countryISO3166numeric", (editor) => {
     insertAtPosition(editor, () => countryISO3166numeric());
   });
-  nova.commands.register("random.dateISO8601", (editor) => {
+  nova.commands.register("random.date", (editor) => {
     insertAtPosition(editor, () =>
-      dateISO8601({
+      datestamp({
         minYear: nova.config.get("random.yearMin", "number"),
         maxYear: nova.config.get("random.yearMax", "number"),
-      })
+        format: nova.config.get("random.dateFormat", "string"),
+      }),
     );
   });
-  nova.commands.register("random.timeISO8601", (editor) => {
+  nova.commands.register("random.time", (editor) => {
     insertAtPosition(editor, () =>
-      timeISO8601({
+      timestamp({
         minYear: nova.config.get("random.yearMin", "number"),
         maxYear: nova.config.get("random.yearMax", "number"),
-      })
+        format: nova.config.get("random.timeFormat", "string"),
+        includeSeconds: nova.config.get("random.timeIncludeSeconds", "boolean"),
+      }),
     );
   });
   nova.commands.register("random.datetimeISO8601", (editor) => {
@@ -134,7 +137,7 @@ export function activate() {
         minYear: nova.config.get("random.yearMin", "number"),
         maxYear: nova.config.get("random.yearMax", "number"),
         timezoneType: nova.config.get("random.generateTimezones", "string"),
-      })
+      }),
     );
   });
   nova.commands.register("random.hashMD5", (editor) => {
@@ -160,7 +163,7 @@ export function activate() {
       insertAtPosition(editor, () =>
         numberFloat({
           range: nova.config.get("random.defaultNumberRange", "string"),
-        })
+        }),
       );
     } else {
       promptForInput({
@@ -175,9 +178,9 @@ export function activate() {
               range,
               decimalPlaces: nova.config.get(
                 "random.floatDecimalPlaces",
-                "number"
+                "number",
               ),
-            })
+            }),
           );
         },
       });
@@ -188,7 +191,7 @@ export function activate() {
       insertAtPosition(editor, () =>
         numberInt({
           range: nova.config.get("random.defaultNumberRange", "string"),
-        })
+        }),
       );
     } else {
       promptForInput({
@@ -208,7 +211,7 @@ export function activate() {
       insertAtPosition(editor, () =>
         numberBinary({
           range: nova.config.get("random.defaultNumberRange", "string"),
-        })
+        }),
       );
     } else {
       promptForInput({
@@ -227,21 +230,21 @@ export function activate() {
     insertAtPosition(editor, () =>
       stringAlphanumeric({
         length: nova.config.get("random.stringLength", "number"),
-      })
+      }),
     );
   });
   nova.commands.register("random.stringAlphabetical", (editor) => {
     insertAtPosition(editor, () =>
       stringAlphabetical({
         length: nova.config.get("random.stringLength", "number"),
-      })
+      }),
     );
   });
   nova.commands.register("random.stringPassword", (editor) => {
     insertAtPosition(editor, () =>
       stringPassword({
         length: nova.config.get("random.stringLength", "number"),
-      })
+      }),
     );
   });
   nova.commands.register("random.stringSingleLetter", (editor) => {
@@ -260,14 +263,14 @@ export function activate() {
     insertAtPosition(editor, () =>
       webDomainName({
         domainExtensions: nova.config.get("random.domainTLDs", "array"),
-      })
+      }),
     );
   });
   nova.commands.register("random.webURL", (editor) => {
     insertAtPosition(editor, () =>
       webURL({
         domainExtensions: nova.config.get("random.domainTLDs", "array"),
-      })
+      }),
     );
   });
   nova.commands.register("random.webEmail", (editor) => {
@@ -276,9 +279,9 @@ export function activate() {
         domainExtensions: nova.config.get("random.domainTLDs", "array"),
         useRealEmailDomains: nova.config.get(
           "random.useRealEmailDomains",
-          "boolean"
+          "boolean",
         ),
-      })
+      }),
     );
   });
 }

--- a/tests/datetime.test.mjs
+++ b/tests/datetime.test.mjs
@@ -1,41 +1,64 @@
 import { repeat } from "./util/helpers";
-import {
-  dateISO8601,
-  timeISO8601,
-  datetimeISO8601,
-} from "../src/generators/datetime";
+import { date, time, datetimeISO8601 } from "../src/generators/datetime";
 
-const dateRegex = "[0-9]{4}-[0-9]{2}-[0-9]{2}";
-const timeRegex = "[0-9]{2}:[0-9]{2}:[0-9]{2}";
+const isoDateRegex = "[0-9]{4}-[0-9]{2}-[0-9]{2}";
+const ddmmDateRegex = "[0-9]{2}/[0-9]{2}/[0-9]{4}";
+
+const secondsRegex = ":[0-9]{2}";
+
+const h24TimeRegex = "[0-9]{2}:[0-9]{2}";
+const h24TimeWithSecondsRegex = `${h24TimeRegex}${secondsRegex}`;
+const h24TimeWithoutSecondsRegex = h24TimeRegex;
+
+const h12TimeSuffixRegex = " [a|p]\.m\.";
+const h12TimeRegex = `[0-9]{1,2}:[0-9]{2}`;
+const h12TimeWithSecondsRegex = `${h12TimeRegex}${secondsRegex}${h12TimeSuffixRegex}`;
+const h12TimeWithoutSecondsRegex = `${h12TimeRegex}${h12TimeSuffixRegex}`;
+
 const zoneRegex = "[+-][0-9]{2}:[0-9]{2}";
 
 describe("datetime", () => {
-  describe("dateISO8601", () => {
+  describe("date", () => {
     it("generates valid dates", () => {
       repeat(5, () => {
-        const date = Date.parse(dateISO8601());
-        return expect(date).not.toBeNaN();
+        const result = Date.parse(date());
+        return expect(result).not.toBeNaN();
       });
     });
 
     it("generates dates that are ISO-8601 formatted", () => {
-      const regex = new RegExp(`^${dateRegex}$`);
-      repeat(5, () => expect(dateISO8601()).toMatch(regex));
+      const regex = new RegExp(`^${isoDateRegex}$`);
+      const config = { format: "iso " };
+      repeat(5, () => expect(date(config)).toMatch(regex));
+    });
+
+    it("generates dates that are DD/MM/YYYY formatted", () => {
+      const regex = new RegExp(`^${ddmmDateRegex}$`);
+      const config = { format: "ddmmyyyy" };
+      repeat(5, () => expect(date(config)).toMatch(regex));
+    });
+
+    it("generates dates that are MM/DD/YYYY formatted", () => {
+      const regex = new RegExp(`^${ddmmDateRegex}$`);
+      const config = { format: "mmddyyyy" };
+      repeat(5, () => expect(date(config)).toMatch(regex));
     });
 
     it("generates dates within a given range - minYear, maxYear", () => {
       const config = { minYear: 2000, maxYear: 2000 };
       repeat(5, () => {
-        const year = dateISO8601(config).substring(0, 4);
+        const year = date(config).substring(0, 4);
         return expect(year).toBe("2000");
       });
     });
   });
 
-  describe("timeISO8601", () => {
+  describe("time", () => {
     it("generates valid times", () => {
+      const config = { format: "24hour", includeSeconds: true };
+
       repeat(5, () => {
-        const timePieces = timeISO8601().split(":");
+        const timePieces = time(config).split(":");
         const hours = timePieces[0] >= 0 && timePieces[0] < 24;
         const minutes = timePieces[1] >= 0 && timePieces[1] < 60;
         const seconds = timePieces[2] >= 0 && timePieces[2] < 60;
@@ -47,9 +70,28 @@ describe("datetime", () => {
       });
     });
 
-    it("generates times that are ISO-8601 formatted", () => {
-      const regex = new RegExp(`^${timeRegex}$`);
-      repeat(5, () => expect(timeISO8601()).toMatch(regex));
+    it("generates times that are 24 hour formatted (with seconds)", () => {
+      const regex = new RegExp(`^${h24TimeWithSecondsRegex}$`);
+      const config = { format: "24hour", includeSeconds: true };
+      repeat(5, () => expect(time(config)).toMatch(regex));
+    });
+
+    it("generates times that are 24 hour formatted (without seconds)", () => {
+      const regex = new RegExp(`^${h24TimeWithoutSecondsRegex}$`);
+      const config = { format: "24hour", includeSeconds: false };
+      repeat(5, () => expect(time(config)).toMatch(regex));
+    });
+
+    it("generates times that are 12 hour formatted (with seconds)", () => {
+      const regex = new RegExp(`^${h12TimeWithSecondsRegex}$`);
+      const config = { format: "12hour", includeSeconds: true };
+      repeat(5, () => expect(time(config)).toMatch(regex));
+    });
+
+    it("generates times that are 12 hour formatted (without seconds)", () => {
+      const regex = new RegExp(`^${h12TimeWithoutSecondsRegex}$`);
+      const config = { format: "12hour", includeSeconds: false };
+      repeat(5, () => expect(time(config)).toMatch(regex));
     });
   });
 
@@ -62,19 +104,21 @@ describe("datetime", () => {
     });
 
     it("generates datetimes that are ISO-8601 formatted", () => {
-      const regex = new RegExp(`^${dateRegex}T${timeRegex}$`);
+      const regex = new RegExp(`^${isoDateRegex}T${h24TimeWithSecondsRegex}$`);
       const config = { timezoneType: "none" };
       repeat(5, () => expect(datetimeISO8601(config)).toMatch(regex));
     });
 
     it("generates datetimes with timezones - UTC timezone", () => {
-      const regex = new RegExp(`^${dateRegex}T${timeRegex}Z$`);
+      const regex = new RegExp(`^${isoDateRegex}T${h24TimeWithSecondsRegex}Z$`);
       const config = { timezoneType: "utc" };
       repeat(5, () => expect(datetimeISO8601(config)).toMatch(regex));
     });
 
     it("generates datetimes with timezones - random offset", () => {
-      const regex = new RegExp(`^${dateRegex}T${timeRegex}${zoneRegex}$`);
+      const regex = new RegExp(
+        `^${isoDateRegex}T${h24TimeWithSecondsRegex}${zoneRegex}$`,
+      );
       const config = { timezoneType: "full" };
       repeat(5, () => expect(datetimeISO8601(config)).toMatch(regex));
     });


### PR DESCRIPTION
Dates can now be generated in three formats:
- YYYY-MM-DD (e.g. 1991-09-22, the default)
- DD/MM/YYYY (e.g. 22/09/1991)
- MM/DD/YYYY (e.g. 09/22/1991)

Times now be generated in two formats:
- 24 hour (e.g. 23:59:59, the default)
- 12 hour (e.g. 11:59:59 p.m.)

Times can now be configured to omit seconds.

All of these options are set via extension settings.