### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    reviewers: [querkmachine]
+    schedule:
+      interval: "cron"
+      cronjob: "0 4 * */1 6"
+    allow:
+      - dependency-type: direct
+    groups:
+      rollup:
+        patterns:
+          - "rollup"
+          - "@rollup/*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    reviewers: [querkmachine]
+    schedule:
+      interval: "cron"
+      cronjob: "0 4 * */1 6"


### PR DESCRIPTION
Outdated GitHub Actions dependencies are stopping tests from running. Also the other dependencies could probably use keeping on top of. 